### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+[![Board Status](https://dev.azure.com/schaumic/0c5ad786-00ad-4f33-9e2d-837cdd2bea74/8fd59d04-09dc-4fbf-b741-249e253249d5/_apis/work/boardbadge/d9f703e6-e575-4d4f-855c-0ffafc97adbf)](https://dev.azure.com/schaumic/0c5ad786-00ad-4f33-9e2d-837cdd2bea74/_boards/board/t/8fd59d04-09dc-4fbf-b741-249e253249d5/Microsoft.RequirementCategory)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#31](https://dev.azure.com/schaumic/0c5ad786-00ad-4f33-9e2d-837cdd2bea74/_workitems/edit/31). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.