### PR TITLE
Fix Jest rootDir

### DIFF
--- a/game-backend/.gitignore
+++ b/game-backend/.gitignore
@@ -4,7 +4,7 @@
 /node_modules
 
 # testing
-/coverage
+/src/coverage
 
 # Ignore built ts files
 dist/**/*

--- a/game-backend/jest.config.js
+++ b/game-backend/jest.config.js
@@ -10,4 +10,5 @@ module.exports = {
   },
   testMatch: ['**/*.test.(ts|js)'],
   testEnvironment: 'node',
+  rootDir: 'src'
 };


### PR DESCRIPTION
Set rootDir to src to prevent jest from running tests found in /dist or other directories.