### PR TITLE
AB#52 Implement Walking Intent

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -26,6 +26,7 @@
     "no-plusplus": "off",
     "no-useless-constructor": "off",
     "no-empty-function": "off",
+    "no-param-reassign": ["error", { "props": true, "ignorePropertyModificationsFor": ["draft"] }],
     "@typescript-eslint/no-unused-vars": "warn",
     "semi": "off",
     "@typescript-eslint/semi": ["error"],

--- a/darwin-types/Arena.ts
+++ b/darwin-types/Arena.ts
@@ -1,0 +1,2 @@
+export const ARENA_HEIGHT = 20;
+export const ARENA_WIDTH = 20;

--- a/game-backend/package-lock.json
+++ b/game-backend/package-lock.json
@@ -2695,6 +2695,11 @@
       "integrity": "sha1-SMptcvbGo68Aqa1K5odr44ieKwk=",
       "dev": true
     },
+    "immer": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-6.0.1.tgz",
+      "integrity": "sha512-oXwigCKgznQywsXi1VgrqgWbQEU3wievNCVc4Fcwky6mwXU6YHj6JuYp0WEM/B1EphkqsLr0x18lm5OiuemPcA=="
+    },
     "import-lazy": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-2.1.0.tgz",

--- a/game-backend/package.json
+++ b/game-backend/package.json
@@ -27,6 +27,7 @@
   },
   "dependencies": {
     "hyperid": "^2.0.3",
+    "immer": "^6.0.1",
     "ws": "^7.2.1"
   }
 }

--- a/game-backend/src/game-engine/intent/MoveIntent.test.ts
+++ b/game-backend/src/game-engine/intent/MoveIntent.test.ts
@@ -1,26 +1,63 @@
 import MoveIntent, { Direction } from './MoveIntent';
+import StateBuilder from '../../test-helper/StateBuilder';
+import { ARENA_HEIGHT } from '../../../../darwin-types/Arena';
 
 describe('MoveIntent', () => {
   it('handles move properly', () => {
     const intent = new MoveIntent(Direction.Down);
 
     const newState = intent.execute(
-      {
-        objectMap: {
-          unit1: {
-            id: 'unit1',
-            position: {
-              x: 0,
-              y: 0,
-            },
-          },
-        },
-        objectIds: ['unit1'],
-      },
+      StateBuilder.buildState()
+        .addObject({ id: 'unit1', x: 0, y: 0 })
+        .build(),
       {
         unitId: 'unit1',
       }
     );
     expect(newState.objectMap.unit1.position.y).toBe(1);
+  });
+
+  it('handles position conflicts properly', () => {
+    const intent = new MoveIntent(Direction.Down);
+
+    const newState = intent.execute(
+      StateBuilder.buildState()
+        .addObject({ id: 'unit1', x: 0, y: 0 })
+        .addObject({ id: 'unit2', x: 0, y: 1 })
+        .build(),
+      {
+        unitId: 'unit1',
+      }
+    );
+    expect(newState.objectMap.unit1.position.y).toBe(0);
+    expect(newState.objectMap.unit2.position.y).toBe(1);
+  });
+
+  it('handles lower system boundaries', () => {
+    const intent = new MoveIntent(Direction.Up);
+
+    const newState = intent.execute(
+      StateBuilder.buildState()
+        .addObject({ id: 'unit1', x: 0, y: 0 })
+        .build(),
+      {
+        unitId: 'unit1',
+      }
+    );
+    expect(newState.objectMap.unit1.position.y).toBe(0);
+  });
+
+  it('handles upper system boundaries', () => {
+    const intent = new MoveIntent(Direction.Down);
+
+    const newState = intent.execute(
+      StateBuilder.buildState()
+        .addObject({ id: 'unit1', x: 0, y: ARENA_HEIGHT })
+        .build(),
+      {
+        unitId: 'unit1',
+      }
+    );
+    expect(newState.objectMap.unit1.position.y).toBe(ARENA_HEIGHT);
   });
 });

--- a/game-backend/src/game-engine/intent/MoveIntent.test.ts
+++ b/game-backend/src/game-engine/intent/MoveIntent.test.ts
@@ -1,23 +1,64 @@
 import MoveIntent, { Direction } from './MoveIntent';
 import StateBuilder from '../../test-helper/StateBuilder';
-import { ARENA_HEIGHT } from '../../../../darwin-types/Arena';
+import { ARENA_HEIGHT, ARENA_WIDTH } from '../../../../darwin-types/Arena';
+import { UserContext } from '../../../../darwin-types/UserContext';
+import { State } from '../../../../darwin-types/State';
 
 describe('MoveIntent', () => {
-  it('handles move properly', () => {
-    const intent = new MoveIntent(Direction.Down);
+  const UNIT_ID = 'unit1';
+  let neutralPositionState: State;
+  let lowerPositionState: State;
+  let upperPositionState: State;
+  let baseUserContext: UserContext;
 
-    const newState = intent.execute(
-      StateBuilder.buildState()
-        .addObject({ id: 'unit1', x: 0, y: 0 })
-        .build(),
-      {
-        unitId: 'unit1',
-      }
-    );
-    expect(newState.objectMap.unit1.position.y).toBe(1);
+  beforeEach(() => {
+    neutralPositionState = StateBuilder.buildState()
+      .addObject({ id: UNIT_ID, x: 1, y: 1 })
+      .build();
+    lowerPositionState = StateBuilder.buildState()
+      .addObject({ id: UNIT_ID, x: 0, y: 0 })
+      .build();
+    upperPositionState = StateBuilder.buildState()
+      .addObject({ id: UNIT_ID, x: ARENA_WIDTH, y: ARENA_HEIGHT })
+      .build();
+    baseUserContext = {
+      unitId: UNIT_ID,
+    };
   });
 
-  it('handles position conflicts properly', () => {
+  it('handles move down properly', () => {
+    const intent = new MoveIntent(Direction.Down);
+
+    const newState = intent.execute(neutralPositionState, baseUserContext);
+
+    expect(newState.objectMap[UNIT_ID].position.y).toBe(2);
+  });
+
+  it('handles move up properly', () => {
+    const intent = new MoveIntent(Direction.Up);
+
+    const newState = intent.execute(neutralPositionState, baseUserContext);
+
+    expect(newState.objectMap[UNIT_ID].position.y).toBe(0);
+  });
+
+  it('handles move right properly', () => {
+    const intent = new MoveIntent(Direction.Right);
+
+    const newState = intent.execute(neutralPositionState, baseUserContext);
+
+    expect(newState.objectMap[UNIT_ID].position.x).toBe(2);
+  });
+
+  it('handles move left properly', () => {
+    const intent = new MoveIntent(Direction.Left);
+
+    const newState = intent.execute(neutralPositionState, baseUserContext);
+
+    expect(newState.objectMap[UNIT_ID].position.x).toBe(0);
+  });
+
+  it('handles position conflicts', () => {
     const intent = new MoveIntent(Direction.Down);
 
     const newState = intent.execute(
@@ -25,39 +66,42 @@ describe('MoveIntent', () => {
         .addObject({ id: 'unit1', x: 0, y: 0 })
         .addObject({ id: 'unit2', x: 0, y: 1 })
         .build(),
-      {
-        unitId: 'unit1',
-      }
+      baseUserContext
     );
-    expect(newState.objectMap.unit1.position.y).toBe(0);
+
+    expect(newState.objectMap[UNIT_ID].position.y).toBe(0);
     expect(newState.objectMap.unit2.position.y).toBe(1);
   });
 
-  it('handles lower system boundaries', () => {
+  it('handles lower y system boundaries', () => {
     const intent = new MoveIntent(Direction.Up);
 
-    const newState = intent.execute(
-      StateBuilder.buildState()
-        .addObject({ id: 'unit1', x: 0, y: 0 })
-        .build(),
-      {
-        unitId: 'unit1',
-      }
-    );
-    expect(newState.objectMap.unit1.position.y).toBe(0);
+    const newState = intent.execute(lowerPositionState, baseUserContext);
+
+    expect(newState.objectMap[UNIT_ID].position.y).toBe(0);
   });
 
-  it('handles upper system boundaries', () => {
+  it('handles lower x system boundaries', () => {
+    const intent = new MoveIntent(Direction.Left);
+
+    const newState = intent.execute(lowerPositionState, baseUserContext);
+
+    expect(newState.objectMap[UNIT_ID].position.x).toBe(0);
+  });
+
+  it('handles upper y system boundaries', () => {
     const intent = new MoveIntent(Direction.Down);
 
-    const newState = intent.execute(
-      StateBuilder.buildState()
-        .addObject({ id: 'unit1', x: 0, y: ARENA_HEIGHT })
-        .build(),
-      {
-        unitId: 'unit1',
-      }
-    );
-    expect(newState.objectMap.unit1.position.y).toBe(ARENA_HEIGHT);
+    const newState = intent.execute(upperPositionState, baseUserContext);
+
+    expect(newState.objectMap[UNIT_ID].position.y).toBe(ARENA_HEIGHT);
+  });
+
+  it('handles upper x system boundaries', () => {
+    const intent = new MoveIntent(Direction.Right);
+
+    const newState = intent.execute(upperPositionState, baseUserContext);
+
+    expect(newState.objectMap[UNIT_ID].position.x).toBe(ARENA_WIDTH);
   });
 });

--- a/game-backend/src/test-helper/StateBuilder.ts
+++ b/game-backend/src/test-helper/StateBuilder.ts
@@ -1,0 +1,36 @@
+import produce from 'immer';
+import { State } from '../../../darwin-types/State';
+
+export interface GameObject {
+  id: string;
+  x: number;
+  y: number;
+}
+
+export default class StateBuilder {
+  constructor(private state: State) {
+    return this;
+  }
+
+  addObject({ id, x, y }: GameObject): StateBuilder {
+    this.state = produce(this.state, draft => {
+      draft.objectMap[id] = {
+        id,
+        position: { x, y },
+      };
+      draft.objectIds.push(id);
+    });
+    return this;
+  }
+
+  build(): State {
+    return this.state;
+  }
+
+  static buildState(): StateBuilder {
+    return new StateBuilder({
+      objectMap: {},
+      objectIds: [],
+    });
+  }
+}


### PR DESCRIPTION
Basic implementation for MoveIntent.

Uses `Immer` for handling state mutations nicely.
Define basic test for MoveIntent.
Define reusable Test StateBuilder.