### PR TITLE
AB#65 Implement Update User Script on backend

### DIFF
--- a/darwin-types/messages/MatchUpdate.ts
+++ b/darwin-types/messages/MatchUpdate.ts
@@ -1,7 +1,8 @@
 import { Tick } from '../Tick';
 import { State } from '../State';
+import { Message } from './Message';
 
-export interface MatchUpdate {
+export interface MatchUpdate extends Message {
   type: 'matchUpdate';
   payload: {
     state: State;

--- a/darwin-types/messages/Message.ts
+++ b/darwin-types/messages/Message.ts
@@ -1,0 +1,4 @@
+export interface Message {
+  type: string;
+  payload: {};
+}

--- a/darwin-types/messages/ScriptUpdate.ts
+++ b/darwin-types/messages/ScriptUpdate.ts
@@ -1,0 +1,8 @@
+import { Message } from './Message';
+
+export interface ScriptUpdate extends Message {
+  type: 'scriptUpdate';
+  payload: {
+    script: string;
+  };
+}

--- a/game-backend/src/MainController.test.ts
+++ b/game-backend/src/MainController.test.ts
@@ -6,11 +6,14 @@ describe('MainController', () => {
   // Websocket mocks
   const sendFunction0 = jest.fn();
   const sendFunction1 = jest.fn();
+  const onFunction = jest.fn();
   const wsMock0: unknown = {
     send: sendFunction0,
+    on: onFunction,
   };
   const wsMock1: unknown = {
     send: sendFunction1,
+    on: onFunction,
   };
 
   let mainController: MainController;

--- a/game-backend/src/MainController.ts
+++ b/game-backend/src/MainController.ts
@@ -1,9 +1,15 @@
 import WebSocket from 'ws';
 import hyperid from 'hyperid';
 import { GameObject } from '../../darwin-types/GameObject';
-import { UserContext } from '../../darwin-types/UserContext';
-import { createStore, ConnectionId } from './ServerStore';
+import {
+  UserContextId,
+  UserExecutionContext,
+} from '../../darwin-types/UserContext';
+import { ConnectionId, createStore } from './ServerStore';
 import { MatchUpdate } from '../../darwin-types/messages/MatchUpdate';
+import performTick from './game-engine';
+import { Message } from '../../darwin-types/messages/Message';
+import { ScriptUpdate } from '../../darwin-types/messages/ScriptUpdate';
 
 export const TICK_INTERVAL = 2000;
 
@@ -22,6 +28,17 @@ export default class MainController {
   newConnection(ws: WebSocket, connectionId: ConnectionId): void {
     this.store.connections.push([connectionId, ws]);
 
+    ws.on('message', (data: string) => {
+      const message = JSON.parse(data) as Message;
+      switch (message.type) {
+        case 'scriptUpdate':
+          this.handleUserScript(connectionId, message as ScriptUpdate);
+          break;
+        default:
+          break;
+      }
+    });
+
     // generate a unit
     const unitId = this.hyperIdInstance();
     const unit: GameObject = {
@@ -37,13 +54,28 @@ export default class MainController {
     this.store.matchState.objectIds.push(unit.id);
 
     // add the generated unit to the user context
-    const userCtx: UserContext = { unitId };
+    const userCtx: UserExecutionContext = {
+      unitId,
+      userScript: {
+        script: '',
+      },
+    };
     this.store.userContexts.userContextMap[connectionId] = userCtx;
     this.store.userContexts.userContextIds.push(connectionId);
 
     if (!this.isTicking && this.store.connections.length) {
       this.startTicking();
     }
+  }
+
+  handleUserScript(userContextId: UserContextId, message: ScriptUpdate): void {
+    this.updateUserScript(userContextId, message.payload.script);
+  }
+
+  updateUserScript(userContextId: UserContextId, script: string): void {
+    this.store.userContexts.userContextMap[
+      userContextId
+    ].userScript.script = script;
   }
 
   private startTicking(): void {
@@ -58,6 +90,10 @@ export default class MainController {
 
   private generateMatchUpdate(): MatchUpdate {
     this.store.currentTick++;
+    const userContexts = this.store.userContexts.userContextIds.map(
+      id => this.store.userContexts.userContextMap[id]
+    );
+    this.store.matchState = performTick(this.store.matchState, userContexts);
     return {
       type: 'matchUpdate',
       payload: {

--- a/game-backend/src/ServerStore.ts
+++ b/game-backend/src/ServerStore.ts
@@ -1,5 +1,8 @@
 import WebSocket from 'ws';
-import { UserContext, UserContextId } from '../../darwin-types/UserContext';
+import {
+  UserContextId,
+  UserExecutionContext,
+} from '../../darwin-types/UserContext';
 import { State } from '../../darwin-types/State';
 
 export type ConnectionId = string;
@@ -7,7 +10,7 @@ export type ConnectionId = string;
 export interface ServerStore {
   matchState: State;
   userContexts: {
-    userContextMap: Record<UserContextId, UserContext>;
+    userContextMap: Record<UserContextId, UserExecutionContext>;
     userContextIds: UserContextId[];
   };
   connections: [ConnectionId, WebSocket][];

--- a/game-backend/src/game-engine/index.ts
+++ b/game-backend/src/game-engine/index.ts
@@ -16,11 +16,13 @@ function performTick(state: State, scripts: UserExecutionContext[]): State {
       try {
         const intents = recordIntents(executionContext.userScript);
         return {
+          context: executionContext,
           intents,
         };
       } catch (e) {
         // assume no intents in case of script error
         return {
+          context: executionContext,
           intents: [],
         };
       }

--- a/game-backend/src/game-engine/intent/Intent.ts
+++ b/game-backend/src/game-engine/intent/Intent.ts
@@ -1,5 +1,8 @@
 import { State } from '../../../../darwin-types/State';
-import { UserContext } from '../../../../darwin-types/UserContext';
+import {
+  UserContext,
+  UserExecutionContext,
+} from '../../../../darwin-types/UserContext';
 
 /**
  * Represents an action dispatched by a user script.
@@ -15,5 +18,6 @@ export interface Intent {
  * Stores the intents of a user during a single tick.
  */
 export interface UserTickIntents {
+  context: UserExecutionContext;
   intents: Intent[];
 }

--- a/game-backend/src/game-engine/scheduleIntents.test.ts
+++ b/game-backend/src/game-engine/scheduleIntents.test.ts
@@ -12,6 +12,12 @@ describe('scheduleIntents', () => {
     mockExecute.mockReturnValueOnce(state);
     const newState = scheduleIntents(getDummyState(), [
       {
+        context: {
+          userScript: {
+            script: '',
+          },
+          unitId: '',
+        },
         intents: [
           {
             execute: mockExecute,

--- a/game-backend/src/game-engine/scheduleIntents.ts
+++ b/game-backend/src/game-engine/scheduleIntents.ts
@@ -14,7 +14,7 @@ function scheduleIntents(
   return userTicks.reduce(
     (userState, userTickIntents) =>
       userTickIntents.intents.reduce(
-        (state, intent) => intent.execute(state, null),
+        (state, intent) => intent.execute(state, userTickIntents.context),
         userState
       ),
     initialState


### PR DESCRIPTION
Integrate game-engine.
Add UpdateScript possibility.

This finishes the backend loop to permit user scripts and using them for the next tick.