### PR TITLE
AB#92 Backend Persistence Handling

### DIFF
--- a/darwin-types/Connection.ts
+++ b/darwin-types/Connection.ts
@@ -1,0 +1,1 @@
+export type ConnectionId = string;

--- a/darwin-types/Connection.ts
+++ b/darwin-types/Connection.ts
@@ -1,1 +1,0 @@
-export type ConnectionId = string;

--- a/darwin-types/UserContext.ts
+++ b/darwin-types/UserContext.ts
@@ -1,6 +1,6 @@
 import { ObjectId } from './game-objects/GameObject';
 
-export type UserContextId = string;
+export type UserId = string;
 
 export interface UserContext {
   unitId: ObjectId;

--- a/darwin-types/messages/ConnectionInitialization.ts
+++ b/darwin-types/messages/ConnectionInitialization.ts
@@ -1,9 +1,9 @@
 import { Message } from './Message';
-import { ConnectionId } from '../Connection';
+import { UserId } from '../UserContext';
 
 export interface ConnectionInitialization extends Message {
   type: 'connectionInitialization';
   payload: {
-    connectionId: ConnectionId;
+    userId: UserId;
   };
 }

--- a/darwin-types/messages/ConnectionInitialization.ts
+++ b/darwin-types/messages/ConnectionInitialization.ts
@@ -1,0 +1,9 @@
+import { Message } from './Message';
+import { ConnectionId } from '../../game-backend/src/ServerStore';
+
+export interface ConnectionInitialization extends Message {
+  type: 'connectionInitialization';
+  payload: {
+    connectionId: ConnectionId;
+  };
+}

--- a/darwin-types/messages/ConnectionInitialization.ts
+++ b/darwin-types/messages/ConnectionInitialization.ts
@@ -1,5 +1,5 @@
 import { Message } from './Message';
-import { ConnectionId } from '../../game-backend/src/ServerStore';
+import { ConnectionId } from '../Connection';
 
 export interface ConnectionInitialization extends Message {
   type: 'connectionInitialization';

--- a/game-backend/src/MainController.test.ts
+++ b/game-backend/src/MainController.test.ts
@@ -43,9 +43,7 @@ describe('MainController', () => {
       sendFunction0.mock.calls[0][0]
     );
     expect(connectionInitialization.type).toBe('connectionInitialization');
-    expect(connectionInitialization.payload.connectionId).not.toBe(
-      'connection0'
-    );
+    expect(connectionInitialization.payload.userId).not.toBe('connection0');
   });
 
   it('sends the previous connection id back', () => {
@@ -58,7 +56,7 @@ describe('MainController', () => {
     // second one
     mainController.newConnection(
       wsMock1 as WebSocket,
-      connectionInitialization0.payload.connectionId
+      connectionInitialization0.payload.userId
     );
     const connectionInitialization1 = parseConnectionInitialization(
       sendFunction1.mock.calls[0][0]
@@ -66,8 +64,8 @@ describe('MainController', () => {
 
     // assert
     expect(connectionInitialization1.type).toBe('connectionInitialization');
-    expect(connectionInitialization1.payload.connectionId).toBe(
-      connectionInitialization0.payload.connectionId
+    expect(connectionInitialization1.payload.userId).toBe(
+      connectionInitialization0.payload.userId
     );
   });
 

--- a/game-backend/src/MainController.test.ts
+++ b/game-backend/src/MainController.test.ts
@@ -40,7 +40,7 @@ describe('MainController', () => {
     mainController.newConnection(wsMock0 as WebSocket, 'connection0');
     jest.advanceTimersByTime(TICK_INTERVAL);
 
-    const matchUpdate = parseResponseBody(sendFunction0.mock.calls[0][0]);
+    const matchUpdate = parseResponseBody(sendFunction0.mock.calls[1][0]);
     expect(matchUpdate.type).toBe('matchUpdate');
   });
 
@@ -48,7 +48,7 @@ describe('MainController', () => {
     mainController.newConnection(wsMock0 as WebSocket, 'connection0');
     jest.advanceTimersByTime(TICK_INTERVAL);
 
-    const matchUpdate = parseResponseBody(sendFunction0.mock.calls[0][0]);
+    const matchUpdate = parseResponseBody(sendFunction0.mock.calls[1][0]);
     const unitId = matchUpdate.payload.state.objectIds[0];
 
     expect(unitId).not.toBeNull();
@@ -61,11 +61,11 @@ describe('MainController', () => {
     mainController.newConnection(wsMock0 as WebSocket, 'connection0');
 
     jest.advanceTimersByTime(TICK_INTERVAL);
-    matchUpdate = parseResponseBody(sendFunction0.mock.calls[0][0]);
+    matchUpdate = parseResponseBody(sendFunction0.mock.calls[1][0]);
     expect(matchUpdate.payload.meta.currentTick).toBe(1);
 
     jest.advanceTimersByTime(TICK_INTERVAL);
-    matchUpdate = parseResponseBody(sendFunction0.mock.calls[1][0]);
+    matchUpdate = parseResponseBody(sendFunction0.mock.calls[2][0]);
     expect(matchUpdate.payload.meta.currentTick).toBe(2);
   });
 
@@ -94,13 +94,13 @@ describe('MainController', () => {
     jest.advanceTimersByTime(TICK_INTERVAL);
 
     assertStatesMatch(
-      sendFunction0.mock.calls[0][0],
-      sendFunction1.mock.calls[0][0],
+      sendFunction0.mock.calls[1][0],
+      sendFunction1.mock.calls[1][0],
       1
     );
     assertStatesMatch(
-      sendFunction0.mock.calls[1][0],
-      sendFunction1.mock.calls[1][0],
+      sendFunction0.mock.calls[2][0],
+      sendFunction1.mock.calls[2][0],
       2
     );
   });

--- a/game-backend/src/MainController.test.ts
+++ b/game-backend/src/MainController.test.ts
@@ -75,7 +75,9 @@ describe('MainController', () => {
     mainController.newConnection(wsMock0 as WebSocket, 'connection0');
     jest.advanceTimersByTime(TICK_INTERVAL);
 
-    const matchUpdate = parseResponseBody(sendFunction0.mock.calls[1][0]);
+    const matchUpdate: MatchUpdate = parseResponseBody(
+      sendFunction0.mock.calls[1][0]
+    );
     expect(matchUpdate.type).toBe('matchUpdate');
   });
 
@@ -83,7 +85,9 @@ describe('MainController', () => {
     mainController.newConnection(wsMock0 as WebSocket, 'connection0');
     jest.advanceTimersByTime(TICK_INTERVAL);
 
-    const matchUpdate = parseResponseBody(sendFunction0.mock.calls[1][0]);
+    const matchUpdate: MatchUpdate = parseResponseBody(
+      sendFunction0.mock.calls[1][0]
+    );
     const unitId = matchUpdate.payload.state.objectIds[0];
 
     expect(unitId).not.toBeNull();
@@ -109,8 +113,8 @@ describe('MainController', () => {
     updateClient1: string,
     expectedTick: Tick
   ): void {
-    const matchUpdate0 = parseResponseBody(updateClient0);
-    const matchUpdate1 = parseResponseBody(updateClient1);
+    const matchUpdate0: MatchUpdate = parseResponseBody(updateClient0);
+    const matchUpdate1: MatchUpdate = parseResponseBody(updateClient1);
     expect(matchUpdate0.payload.state).toStrictEqual(
       matchUpdate1.payload.state
     );

--- a/game-backend/src/MainController.test.ts
+++ b/game-backend/src/MainController.test.ts
@@ -21,7 +21,13 @@ describe('MainController', () => {
   let mainController: MainController;
   jest.useFakeTimers();
 
-  const parseResponseBody = (body: string): any => {
+  const parseMatchUpdate = (body: string): MatchUpdate => {
+    return JSON.parse(body);
+  };
+
+  const parseConnectionInitialization = (
+    body: string
+  ): ConnectionInitialization => {
     return JSON.parse(body);
   };
 
@@ -33,7 +39,7 @@ describe('MainController', () => {
 
   it('sends a generated connection id back', () => {
     mainController.newConnection(wsMock0 as WebSocket, 'connection0');
-    const connectionInitialization: ConnectionInitialization = parseResponseBody(
+    const connectionInitialization = parseConnectionInitialization(
       sendFunction0.mock.calls[0][0]
     );
     expect(connectionInitialization.type).toBe('connectionInitialization');
@@ -45,7 +51,7 @@ describe('MainController', () => {
   it('sends the previous connection id back', () => {
     // first connection
     mainController.newConnection(wsMock0 as WebSocket, 'connection0');
-    const connectionInitialization0: ConnectionInitialization = parseResponseBody(
+    const connectionInitialization0 = parseConnectionInitialization(
       sendFunction0.mock.calls[0][0]
     );
 
@@ -54,7 +60,7 @@ describe('MainController', () => {
       wsMock1 as WebSocket,
       connectionInitialization0.payload.connectionId
     );
-    const connectionInitialization1: ConnectionInitialization = parseResponseBody(
+    const connectionInitialization1 = parseConnectionInitialization(
       sendFunction1.mock.calls[0][0]
     );
 
@@ -75,9 +81,7 @@ describe('MainController', () => {
     mainController.newConnection(wsMock0 as WebSocket, 'connection0');
     jest.advanceTimersByTime(TICK_INTERVAL);
 
-    const matchUpdate: MatchUpdate = parseResponseBody(
-      sendFunction0.mock.calls[1][0]
-    );
+    const matchUpdate = parseMatchUpdate(sendFunction0.mock.calls[1][0]);
     expect(matchUpdate.type).toBe('matchUpdate');
   });
 
@@ -85,9 +89,7 @@ describe('MainController', () => {
     mainController.newConnection(wsMock0 as WebSocket, 'connection0');
     jest.advanceTimersByTime(TICK_INTERVAL);
 
-    const matchUpdate: MatchUpdate = parseResponseBody(
-      sendFunction0.mock.calls[1][0]
-    );
+    const matchUpdate = parseMatchUpdate(sendFunction0.mock.calls[1][0]);
     const unitId = matchUpdate.payload.state.objectIds[0];
 
     expect(unitId).not.toBeNull();
@@ -95,16 +97,16 @@ describe('MainController', () => {
   });
 
   it('increments tick counter on each tick', () => {
-    let matchUpdate: MatchUpdate;
+    let matchUpdate;
 
     mainController.newConnection(wsMock0 as WebSocket, 'connection0');
 
     jest.advanceTimersByTime(TICK_INTERVAL);
-    matchUpdate = parseResponseBody(sendFunction0.mock.calls[1][0]);
+    matchUpdate = parseMatchUpdate(sendFunction0.mock.calls[1][0]);
     expect(matchUpdate.payload.meta.currentTick).toBe(1);
 
     jest.advanceTimersByTime(TICK_INTERVAL);
-    matchUpdate = parseResponseBody(sendFunction0.mock.calls[2][0]);
+    matchUpdate = parseMatchUpdate(sendFunction0.mock.calls[2][0]);
     expect(matchUpdate.payload.meta.currentTick).toBe(2);
   });
 
@@ -113,8 +115,8 @@ describe('MainController', () => {
     updateClient1: string,
     expectedTick: Tick
   ): void {
-    const matchUpdate0: MatchUpdate = parseResponseBody(updateClient0);
-    const matchUpdate1: MatchUpdate = parseResponseBody(updateClient1);
+    const matchUpdate0 = parseMatchUpdate(updateClient0);
+    const matchUpdate1 = parseMatchUpdate(updateClient1);
     expect(matchUpdate0.payload.state).toStrictEqual(
       matchUpdate1.payload.state
     );

--- a/game-backend/src/MainController.ts
+++ b/game-backend/src/MainController.ts
@@ -1,7 +1,7 @@
 import WebSocket from 'ws';
 import hyperid from 'hyperid';
 import { UserContext, UserContextId } from '../../darwin-types/UserContext';
-import { ConnectionId, createStore, UserEntry } from './ServerStore';
+import { createStore, UserEntry } from './ServerStore';
 import performTick from './game-engine';
 import { Message } from '../../darwin-types/messages/Message';
 import { ScriptUpdate } from '../../darwin-types/messages/ScriptUpdate';
@@ -9,6 +9,7 @@ import { MatchUpdate } from '../../darwin-types/messages/MatchUpdate';
 import GAME_OBJECT_TYPES from './constants/gameObjects';
 import { Unit } from '../../darwin-types/game-objects/Unit';
 import { ConnectionInitialization } from '../../darwin-types/messages/ConnectionInitialization';
+import { ConnectionId } from '../../darwin-types/Connection';
 
 export const TICK_INTERVAL = 2000;
 

--- a/game-backend/src/MainController.ts
+++ b/game-backend/src/MainController.ts
@@ -52,7 +52,7 @@ export default class MainController {
   private getConnectionId(requestedConnectionId: string): ConnectionId {
     if (
       requestedConnectionId &&
-      this.store.userContexts.userContextIds.indexOf(requestedConnectionId)
+      this.store.userContexts.userContextIds.includes(requestedConnectionId)
     ) {
       return requestedConnectionId;
     }
@@ -60,14 +60,13 @@ export default class MainController {
   }
 
   private static sendConnectionId(ws: WebSocket, connectionId: string): void {
-    ws.send(
-      JSON.stringify({
-        type: 'connectionInitialization',
-        payload: {
-          connectionId,
-        },
-      } as ConnectionInitialization)
-    );
+    const message: ConnectionInitialization = {
+      type: 'connectionInitialization',
+      payload: {
+        connectionId,
+      },
+    };
+    ws.send(JSON.stringify(message));
   }
 
   private getMessageListener(connectionId: string) {

--- a/game-backend/src/ServerStore.ts
+++ b/game-backend/src/ServerStore.ts
@@ -5,8 +5,6 @@ import {
 } from '../../darwin-types/UserContext';
 import { State } from '../../darwin-types/State';
 
-export type ConnectionId = string;
-
 export interface UserEntry {
   userContext: UserExecutionContext;
   connections: WebSocket[];

--- a/game-backend/src/ServerStore.ts
+++ b/game-backend/src/ServerStore.ts
@@ -1,8 +1,5 @@
 import WebSocket from 'ws';
-import {
-  UserContextId,
-  UserExecutionContext,
-} from '../../darwin-types/UserContext';
+import { UserId, UserExecutionContext } from '../../darwin-types/UserContext';
 import { State } from '../../darwin-types/State';
 
 export interface UserEntry {
@@ -13,8 +10,8 @@ export interface UserEntry {
 export interface ServerStore {
   matchState: State;
   userContexts: {
-    userContextMap: Record<UserContextId, UserEntry>;
-    userContextIds: UserContextId[];
+    userContextMap: Record<UserId, UserEntry>;
+    userContextIds: UserId[];
   };
   currentTick: number;
 }

--- a/game-backend/src/server.ts
+++ b/game-backend/src/server.ts
@@ -2,7 +2,7 @@ import http from 'http';
 import url from 'url';
 import WebSocket from 'ws';
 import MainController from './MainController';
-import { ConnectionId } from './ServerStore';
+import { ConnectionId } from '../../darwin-types/Connection';
 
 function extractConnectionId(req: http.IncomingMessage): ConnectionId {
   const searchParams = new URLSearchParams(url.parse(req.url).query);

--- a/game-backend/src/server.ts
+++ b/game-backend/src/server.ts
@@ -1,10 +1,15 @@
 import http from 'http';
+import url from 'url';
 import WebSocket from 'ws';
 import MainController from './MainController';
 import { ConnectionId } from './ServerStore';
 
 function extractConnectionId(req: http.IncomingMessage): ConnectionId {
-  return req.headers['sec-websocket-key'] as ConnectionId;
+  const searchParams = new URLSearchParams(url.parse(req.url).query);
+  if (searchParams.has('connectionId')) {
+    return searchParams.get('connectionId');
+  }
+  return null;
 }
 
 // initialize server

--- a/game-backend/src/server.ts
+++ b/game-backend/src/server.ts
@@ -2,12 +2,12 @@ import http from 'http';
 import url from 'url';
 import WebSocket from 'ws';
 import MainController from './MainController';
-import { ConnectionId } from '../../darwin-types/Connection';
+import { UserId } from '../../darwin-types/UserContext';
 
-function extractConnectionId(req: http.IncomingMessage): ConnectionId {
+function extractUserId(req: http.IncomingMessage): UserId {
   const searchParams = new URLSearchParams(url.parse(req.url).query);
-  if (searchParams.has('connectionId')) {
-    return searchParams.get('connectionId');
+  if (searchParams.has('userId')) {
+    return searchParams.get('userId');
   }
   return null;
 }
@@ -20,8 +20,8 @@ const WSServer = new WebSocket.Server({
 const mainController = new MainController();
 
 WSServer.on('connection', (ws: WebSocket, req: http.IncomingMessage) => {
-  const connectionId = extractConnectionId(req);
-  mainController.newConnection(ws, connectionId);
+  const userId = extractUserId(req);
+  mainController.newConnection(ws, userId);
 });
 
 // start server


### PR DESCRIPTION
This is a prototype of the backend implementation.  The idea is that the client will send its past connectionId when initiating a connection. The server then looks it up or generates a new one.

I'm thinking of merging the connectionId and userId together, so everything is a bit clearer. What do you think?