### PR TITLE
Fix html node nesting

### DIFF
--- a/game-frontend/src/components/help/HelpText.tsx
+++ b/game-frontend/src/components/help/HelpText.tsx
@@ -37,8 +37,8 @@ const HelpText: FC = () => {
         der Variable <InlineCode>userUnit</InlineCode> verfügbar. Beispielsweise
         kannst du deine Unit mit diesem Code an die X-Position einer Ressource
         bewegen:
-        <Codeblock>{moveToFoodCodeExample}</Codeblock>
       </p>
+      <Codeblock>{moveToFoodCodeExample}</Codeblock>
     </>
   );
 };


### PR DESCRIPTION
`pre` tags are not permitted as descendants of paragraphs.
Therefore the code block is moved outside of the paragraph.

Removes nasty react warning during development.