### PR TITLE
AB#103 Use safe random user id

### DIFF
--- a/darwin-types/src/messages/ConnectionInitialization.ts
+++ b/darwin-types/src/messages/ConnectionInitialization.ts
@@ -1,9 +1,0 @@
-import { Message } from './Message';
-import { UserId } from '../UserContext';
-
-export interface ConnectionInitialization extends Message {
-  type: 'connectionInitialization';
-  payload: {
-    userId: UserId;
-  };
-}

--- a/darwin-types/src/messages/index.ts
+++ b/darwin-types/src/messages/index.ts
@@ -1,4 +1,3 @@
 export * from './Message';
 export * from './MatchUpdate';
 export * from './ScriptUpdate';
-export * from './ConnectionInitialization';

--- a/game-backend/src/MainController.test.ts
+++ b/game-backend/src/MainController.test.ts
@@ -1,10 +1,5 @@
 import WebSocket, { CLOSED, OPEN } from 'ws';
-import {
-  ConnectionInitialization,
-  MatchUpdate,
-  ScriptUpdate,
-  UserId,
-} from '@darwin/types';
+import { MatchUpdate, ScriptUpdate, UserId } from '@darwin/types';
 import MainController, { GAME_RESTART_TIME } from './MainController';
 
 import * as GameController from './GameController';
@@ -59,12 +54,6 @@ describe('MainController', () => {
     return JSON.parse(body);
   };
 
-  const parseConnectionInitialization = (
-    body: string
-  ): ConnectionInitialization => {
-    return JSON.parse(body);
-  };
-
   beforeEach(() => {
     jest.clearAllMocks();
     jest.clearAllTimers();
@@ -88,46 +77,13 @@ describe('MainController', () => {
     };
   });
 
-  it('sends a generated connection id back', () => {
-    mainController.newConnection(wsMock0 as WebSocket, 'connection0');
-    const connectionInitialization = parseConnectionInitialization(
-      sendFunction0.mock.calls[0][0]
-    );
-    expect(connectionInitialization.type).toBe('connectionInitialization');
-    expect(connectionInitialization.payload.userId).not.toBe('connection0');
-  });
-
-  it('sends the previous connection id back', () => {
-    // first connection
-    mainController.newConnection(wsMock0 as WebSocket, 'connection0');
-    const connectionInitialization0 = parseConnectionInitialization(
-      sendFunction0.mock.calls[0][0]
-    );
-
-    // second connection
-    mainController.newConnection(
-      wsMock1 as WebSocket,
-      connectionInitialization0.payload.userId
-    );
-    const connectionInitialization1 = parseConnectionInitialization(
-      sendFunction1.mock.calls[0][0]
-    );
-
-    // assert
-    expect(connectionInitialization1.type).toBe('connectionInitialization');
-    expect(connectionInitialization1.payload.userId).toBe(
-      connectionInitialization0.payload.userId
-    );
-  });
-
   it('forwards a matchUpdate to the client', () => {
-    mainController.newConnection(wsMock0 as WebSocket, '');
-    const {
-      payload: { userId },
-    } = parseConnectionInitialization(sendFunction0.mock.calls[0][0]);
+    const userId = 'user1';
+    mainController.newConnection(wsMock0 as WebSocket, userId);
+
     sendMatchUpdate(userId, fakeMatchUpdate);
 
-    const matchUpdate = parseMatchUpdate(sendFunction0.mock.calls[1][0]);
+    const matchUpdate = parseMatchUpdate(sendFunction0.mock.calls[0][0]);
     expect(matchUpdate.type).toBe(fakeMatchUpdate.type);
   });
 
@@ -147,16 +103,14 @@ describe('MainController', () => {
   });
 
   it('sends the same update to multiple connections of the same user', () => {
-    mainController.newConnection(wsMock0 as WebSocket, '');
-    const {
-      payload: { userId },
-    } = parseConnectionInitialization(sendFunction0.mock.calls[0][0]);
+    const userId = 'user1';
+    mainController.newConnection(wsMock0 as WebSocket, userId);
     mainController.newConnection(wsMock1 as WebSocket, userId);
 
     sendMatchUpdate(userId, fakeMatchUpdate);
 
-    const matchUpdate0 = parseMatchUpdate(sendFunction0.mock.calls[1][0]);
-    const matchUpdate1 = parseMatchUpdate(sendFunction1.mock.calls[1][0]);
+    const matchUpdate0 = parseMatchUpdate(sendFunction0.mock.calls[0][0]);
+    const matchUpdate1 = parseMatchUpdate(sendFunction1.mock.calls[0][0]);
     expect(matchUpdate0.payload.state).toStrictEqual(
       matchUpdate1.payload.state
     );
@@ -173,17 +127,15 @@ describe('MainController', () => {
   });
 
   it('removes inactive users from store', () => {
-    mainController.newConnection(wsMock0 as WebSocket, '');
-    const {
-      payload: { userId: userId0 },
-    } = parseConnectionInitialization(sendFunction0.mock.calls[0][0]);
-    mainController.newConnection(wsMockDead as WebSocket, '');
+    const userId = 'user1';
+    mainController.newConnection(wsMock0 as WebSocket, userId);
+    mainController.newConnection(wsMockDead as WebSocket, 'user2');
 
     terminate();
     jest.advanceTimersByTime(GAME_RESTART_TIME);
     const mockInstance = GameControllerMock.mock.instances[1];
     const appendUserMock = mockInstance.appendUser as jest.Mock;
     expect(appendUserMock.mock.calls.length).toBe(1);
-    expect(appendUserMock.mock.calls[0][0]).toBe(userId0);
+    expect(appendUserMock.mock.calls[0][0]).toBe(userId);
   });
 });

--- a/game-backend/src/MainController.ts
+++ b/game-backend/src/MainController.ts
@@ -1,12 +1,5 @@
 import WebSocket, { OPEN } from 'ws';
-import hyperid from 'hyperid';
-import {
-  ConnectionInitialization,
-  MatchUpdate,
-  Message,
-  ScriptUpdate,
-  UserId,
-} from '@darwin/types';
+import { MatchUpdate, Message, ScriptUpdate, UserId } from '@darwin/types';
 import GameController from './GameController';
 import { createServerStore } from './createServerStore';
 
@@ -15,8 +8,6 @@ export const GAME_RESTART_TIME = 10000;
 
 export default class MainController {
   private store = createServerStore();
-
-  private hyperIdInstance = hyperid();
 
   private gameController: GameController;
 
@@ -27,11 +18,7 @@ export default class MainController {
     );
   }
 
-  newConnection(ws: WebSocket, requestedUserId: UserId): void {
-    const userId = this.getUserId(requestedUserId);
-
-    MainController.sendUserId(ws, userId);
-
+  newConnection(ws: WebSocket, userId: UserId): void {
     ws.on('message', this.getMessageListener(userId));
 
     const userConnection = this.store.userConnnections.userConnectionMap[
@@ -95,31 +82,6 @@ export default class MainController {
       id => id !== userId
     );
     delete this.store.userConnnections.userConnectionMap[userId];
-  }
-
-  /**
-   * Looks up the connection id in the store.
-   * It returns the found userId or generates a new one respectively.
-   * @param requestedUserId The connection id the client requests
-   */
-  private getUserId(requestedUserId: string): UserId {
-    if (
-      requestedUserId &&
-      this.store.userConnnections.userConnectionIds.includes(requestedUserId)
-    ) {
-      return requestedUserId;
-    }
-    return this.hyperIdInstance();
-  }
-
-  private static sendUserId(ws: WebSocket, userId: UserId): void {
-    const message: ConnectionInitialization = {
-      type: 'connectionInitialization',
-      payload: {
-        userId,
-      },
-    };
-    ws.send(JSON.stringify(message));
   }
 
   private getMessageListener(userId: string) {

--- a/game-backend/src/server.ts
+++ b/game-backend/src/server.ts
@@ -11,10 +11,7 @@ import {
 
 function extractUserId(req: http.IncomingMessage): UserId {
   const searchParams = new URLSearchParams(url.parse(req.url).query);
-  if (searchParams.has('userId')) {
-    return searchParams.get('userId');
-  }
-  return null;
+  return searchParams.get('userId');
 }
 
 // initialize server

--- a/game-frontend/package-lock.json
+++ b/game-frontend/package-lock.json
@@ -2065,6 +2065,11 @@
         "@types/react": "*"
       }
     },
+    "@types/uuid": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-7.0.2.tgz",
+      "integrity": "sha512-8Ly3zIPTnT0/8RCU6Kg/G3uTICf9sRwYOpUzSIM3503tLIKcnJPRuinHhXngJUy2MntrEf6dlpOHXJju90Qh5w=="
+    },
     "@types/yargs": {
       "version": "13.0.8",
       "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.8.tgz",
@@ -11752,6 +11757,13 @@
         "tough-cookie": "~2.5.0",
         "tunnel-agent": "^0.6.0",
         "uuid": "^3.3.2"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+        }
       }
     },
     "request-promise-core": {
@@ -12608,6 +12620,13 @@
       "requires": {
         "faye-websocket": "^0.10.0",
         "uuid": "^3.0.1"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+        }
       }
     },
     "sockjs-client": {
@@ -13815,9 +13834,9 @@
       "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
     },
     "uuid": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-7.0.3.tgz",
+      "integrity": "sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg=="
     },
     "v8-compile-cache": {
       "version": "2.1.0",
@@ -15406,6 +15425,13 @@
       "requires": {
         "ansi-colors": "^3.0.0",
         "uuid": "^3.3.2"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+        }
       }
     },
     "webpack-manifest-plugin": {

--- a/game-frontend/package.json
+++ b/game-frontend/package.json
@@ -37,6 +37,7 @@
     "@types/react-dom": "^16.9.0",
     "@types/styled-components": "^5.0.1",
     "@types/use-persisted-state": "^0.3.0",
+    "@types/uuid": "^7.0.2",
     "monaco-editor": "^0.20.0",
     "pixi-particles": "^4.2.0",
     "pixi.js": "^5.2.1",
@@ -45,7 +46,8 @@
     "react-scripts": "3.4.0",
     "styled-components": "^5.0.1",
     "typescript": "~3.7.2",
-    "use-persisted-state": "^0.3.0"
+    "use-persisted-state": "^0.3.0",
+    "uuid": "^7.0.3"
   },
   "devDependencies": {
     "jest-canvas-mock": "^2.2.0",

--- a/game-frontend/src/service/game/context.ts
+++ b/game-frontend/src/service/game/context.ts
@@ -1,12 +1,7 @@
-import {
-  createContext,
-  useContext,
-  useEffect,
-  useReducer,
-  useRef,
-} from 'react';
+import { createContext, useContext, useEffect, useReducer } from 'react';
 import createPersistedState from 'use-persisted-state';
-import { ConnectionInitialization, Message, UserId } from '@darwin/types';
+import { v4 as uuidv4 } from 'uuid';
+import { Message, UserId } from '@darwin/types';
 import {
   API_URL,
   ContextState,
@@ -23,43 +18,24 @@ export const WebsocketContext = createContext<ContextState>(
 );
 
 export function useWebsocket(): ContextState {
-  const [userId, setUserId] = useUserId<UserId | null>(null);
-  const selfObtainedUserIdRef = useRef<UserId | null>(null);
+  const [userId, setUserId] = useUserId<UserId>(() => uuidv4());
   const [contextState, dispatch] = useReducer(reducer, emptyWebsocketContext);
   const { socket } = contextState;
 
   useEffect(() => {
-    const hasNoActiveUserId = userId === null;
-    const hasObtainedUserIdInCurrentTab =
-      selfObtainedUserIdRef.current === userId;
-    if (hasNoActiveUserId || !hasObtainedUserIdInCurrentTab) {
-      const params = new URLSearchParams();
-      if (userId !== null) {
-        params.set(USER_ID_QUERY_PARAM, userId);
-      }
-      dispatch(
-        socketUpdateAction(new WebSocket(`${API_URL}?${params.toString()}`))
-      );
-    }
+    const params = new URLSearchParams();
+    params.set(USER_ID_QUERY_PARAM, userId);
+
+    dispatch(
+      socketUpdateAction(new WebSocket(`${API_URL}?${params.toString()}`))
+    );
   }, [userId, dispatch]);
 
   useEffect(() => {
-    const handleConnectionInitialization = (
-      message: ConnectionInitialization
-    ): void => {
-      selfObtainedUserIdRef.current = message.payload.userId;
-      setUserId(message.payload.userId);
-    };
     if (socket) {
       socket.addEventListener('message', event => {
         const action: Message = JSON.parse(event.data);
-        switch (action.type) {
-          case 'connectionInitialization':
-            handleConnectionInitialization(action as ConnectionInitialization);
-            break;
-          default:
-            dispatch(action);
-        }
+        dispatch(action);
       });
     }
   }, [socket, setUserId, dispatch]);


### PR DESCRIPTION
Move user id generation to frontend and use uuid instead of hyperid.
This makes ids less predictable and simplifies the id generation.