### PR TITLE
Fix invalid help markup

### DIFF
--- a/game-frontend/src/components/help/HelpText.tsx
+++ b/game-frontend/src/components/help/HelpText.tsx
@@ -105,8 +105,8 @@ const HelpText: FC = () => {
         Gegner attackieren, welcher in Reichweite ist. Du Kannst das Unit-Objekt
         deiner Wahl als übergabe Parameter mitgeben. Die{' '}
         <InlineCode>nearestEnemyUnit</InlineCode> ist als default-Wert gesetzt.
-        <Codeblock>attack(nearestEnemyUnit)</Codeblock>
       </p>
+      <Codeblock>attack(nearestEnemyUnit)</Codeblock>
       <h4>Power-ups</h4>
       <p>
         Mit dem Konsumieren eines Powerups kann sich der Spieler einen Vorteil

--- a/game-frontend/src/components/help/OneFieldStage.tsx
+++ b/game-frontend/src/components/help/OneFieldStage.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 import { Stage } from '@inlet/react-pixi';
 import { FIELD_SIZE } from '../../constants/stage';
 
-const Container = styled.div`
+const Container = styled.span`
   vertical-align: middle;
   display: inline-block;
   width: ${FIELD_SIZE / 2}px;


### PR DESCRIPTION
Use proper tags for nesting.
This removes nasty React warnings from dev tools.